### PR TITLE
feat(issue-5): github:5

### DIFF
--- a/src/components/GameControlButtons.js
+++ b/src/components/GameControlButtons.js
@@ -10,12 +10,14 @@ const executionQueue = new ExecutionQueue();
  *
  * Props:
  *   parsedActions {Array<{action: string}>} - Actions returned by CommandParser.
- *   gridSize      {number}                  - Grid side length, used for boundary checks.
+ *   nivel         {object}                  - Loaded level data (gridSize, goal, obstacles).
+ *   onSuccess     {Function}                - Called when the hero reaches the goal.
+ *   onFailure     {Function}                - Called when the hero hits an obstacle.
  */
-function GameControlButtons({ parsedActions, gridSize }) {
+function GameControlButtons({ parsedActions, nivel, onSuccess, onFailure }) {
   function handleExecute() {
-    if (!parsedActions || parsedActions.length === 0) return;
-    executionQueue.startTickLoop(parsedActions, gridSize);
+    if (!parsedActions || parsedActions.length === 0 || !nivel) return;
+    executionQueue.startTickLoop(parsedActions, nivel, 500, onSuccess, onFailure);
   }
 
   return (

--- a/src/components/Grid.js
+++ b/src/components/Grid.js
@@ -1,50 +1,65 @@
 import React, { useRef, useEffect, useCallback, useState } from 'react';
 import { GridRenderer } from '../services/GridRenderer';
 import { gameStateManager } from '../stores/GameStateManager';
+import { levels } from '../levels/levels';
 import CommandInput from './CommandInput';
 import GameControlButtons from './GameControlButtons';
 
 const gridRenderer = new GridRenderer();
 
+// Load Level 1 immediately so the singleton has the correct initial state
+const NIVEL = levels[0];
+gameStateManager.loadLevel(NIVEL);
+
 /**
  * Grid
  * React component that renders a square logic-grid using HTML5 Canvas.
+ * Loads Level 1 on mount, renders obstacles and a blinking goal, and displays
+ * a status message when the player wins or collides with an obstacle.
  *
  * Props:
- *   tamanhoDoGrid  {number} - Number of cells per side (default: 8)
- *   tamanhoDaCelula {number} - Pixel size of each cell before responsive scaling (default: 60)
+ *   tamanhoDaCelula {number} - Max pixel size of each cell before responsive scaling (default: 100)
  */
-function Grid({ tamanhoDoGrid = 8, tamanhoDaCelula = 60 }) {
+function Grid({ tamanhoDaCelula = 100 }) {
   const canvasRef = useRef(null);
   const containerRef = useRef(null);
 
   // Mirror the hero state so React re-renders when it changes
-  const [heroi, setHeroi] = useState(() => gameStateManager.heroi);
+  const [heroi, setHeroi] = useState(() => ({ ...gameStateManager.heroi }));
 
   // Holds the last successfully parsed actions, ready for execution
   const [pendingActions, setPendingActions] = useState([]);
 
+  // Toggles every 500 ms to produce the goal blink effect
+  const [blinkVisible, setBlinkVisible] = useState(true);
+
+  // 'success' | 'failure' | null
+  const [gameResult, setGameResult] = useState(null);
+
   // Subscribe to GameStateManager updates
   useEffect(() => {
     const unsubscribe = gameStateManager.subscribe((state) => {
-      // Spread to produce a new object reference and trigger re-render
       setHeroi({ ...state.heroi });
     });
     return unsubscribe;
   }, []);
 
+  // Blink interval — toggles goal visibility at 500 ms
+  useEffect(() => {
+    const id = setInterval(() => setBlinkVisible((v) => !v), 500);
+    return () => clearInterval(id);
+  }, []);
+
   /**
    * Computes the largest cell size that keeps the grid square and fits inside
-   * the current container while respecting the requested cell size as a
-   * maximum.  Returns the adjusted cell size.
+   * the current container while respecting tamanhoDaCelula as a maximum.
    */
   const calcCellSize = useCallback(() => {
     if (!containerRef.current) return tamanhoDaCelula;
     const { clientWidth, clientHeight } = containerRef.current;
     const available = Math.min(clientWidth, clientHeight);
-    // Never exceed the requested cell size; shrink to fit if needed
-    return Math.min(tamanhoDaCelula, Math.floor(available / tamanhoDoGrid));
-  }, [tamanhoDoGrid, tamanhoDaCelula]);
+    return Math.min(tamanhoDaCelula, Math.floor(available / NIVEL.gridSize));
+  }, [tamanhoDaCelula]);
 
   /** Resize the canvas element and repaint the grid. */
   const draw = useCallback(() => {
@@ -52,17 +67,16 @@ function Grid({ tamanhoDoGrid = 8, tamanhoDaCelula = 60 }) {
     if (!canvas) return;
 
     const cellSize = calcCellSize();
-    const totalSize = tamanhoDoGrid * cellSize;
+    const totalSize = NIVEL.gridSize * cellSize;
 
-    // Keep the canvas bitmap in sync with the computed size
     canvas.width = totalSize;
     canvas.height = totalSize;
 
     const ctx = canvas.getContext('2d');
-    gridRenderer.renderGrid(ctx, tamanhoDoGrid, cellSize, heroi);
-  }, [tamanhoDoGrid, calcCellSize, heroi]);
+    gridRenderer.renderGrid(ctx, NIVEL.gridSize, cellSize, heroi, NIVEL, blinkVisible);
+  }, [calcCellSize, heroi, blinkVisible]);
 
-  // Redraw whenever hero state or layout changes
+  // Redraw whenever hero state, blink phase, or layout changes
   useEffect(() => {
     draw();
 
@@ -71,14 +85,31 @@ function Grid({ tamanhoDoGrid = 8, tamanhoDaCelula = 60 }) {
     return () => window.removeEventListener('resize', handleResize);
   }, [draw]);
 
+  function handleExecute(actions) {
+    setGameResult(null);
+    setPendingActions(actions);
+  }
+
   return (
     <div style={styles.outer}>
       <div ref={containerRef} style={styles.container}>
         <canvas ref={canvasRef} style={styles.canvas} />
       </div>
       <div style={styles.sidebar}>
-        <CommandInput onExecute={setPendingActions} />
-        <GameControlButtons parsedActions={pendingActions} gridSize={tamanhoDoGrid} />
+        <div style={styles.levelBadge}>Fase {NIVEL.id}</div>
+        <CommandInput onExecute={handleExecute} />
+        <GameControlButtons
+          parsedActions={pendingActions}
+          nivel={NIVEL}
+          onSuccess={() => setGameResult('success')}
+          onFailure={() => setGameResult('failure')}
+        />
+        {gameResult === 'success' && (
+          <div style={styles.resultSuccess}>Fase Concluída!</div>
+        )}
+        {gameResult === 'failure' && (
+          <div style={styles.resultFailure}>Obstáculo! Herói resetado.</div>
+        )}
       </div>
     </div>
   );
@@ -104,12 +135,36 @@ const styles = {
   },
   canvas: {
     display: 'block',
-    // Aspect ratio is maintained via canvas.width/height set in draw()
   },
   sidebar: {
     display: 'flex',
     flexDirection: 'column',
     gap: '8px',
+    padding: '16px',
+  },
+  levelBadge: {
+    fontFamily: 'monospace',
+    fontSize: '14px',
+    fontWeight: 'bold',
+    color: '#555',
+  },
+  resultSuccess: {
+    fontFamily: 'monospace',
+    fontSize: '14px',
+    padding: '8px 12px',
+    backgroundColor: '#E8F5E9',
+    color: '#2E7D32',
+    border: '1px solid #A5D6A7',
+    borderRadius: '4px',
+  },
+  resultFailure: {
+    fontFamily: 'monospace',
+    fontSize: '14px',
+    padding: '8px 12px',
+    backgroundColor: '#FFEBEE',
+    color: '#C62828',
+    border: '1px solid #EF9A9A',
+    borderRadius: '4px',
   },
 };
 

--- a/src/levels/levels.js
+++ b/src/levels/levels.js
@@ -1,0 +1,22 @@
+/**
+ * Level definitions for LogicGrid.
+ *
+ * Each level schema:
+ *   id        {number}   - Unique level identifier.
+ *   gridSize  {number}   - Number of cells per side (square grid).
+ *   start     {object}   - Hero spawn: { x, y, dir } where dir is 'Norte'|'Sul'|'Leste'|'Oeste'.
+ *   goal      {object}   - Win cell: { x, y }.
+ *   obstacles {object[]} - Impassable cells: [{ x, y }, ...].
+ */
+export const levels = [
+  {
+    id: 1,
+    gridSize: 5,
+    start: { x: 0, y: 0, dir: 'Leste' },
+    goal: { x: 4, y: 4 },
+    obstacles: [
+      { x: 2, y: 2 },
+      { x: 2, y: 3 },
+    ],
+  },
+];

--- a/src/services/ExecutionQueue.js
+++ b/src/services/ExecutionQueue.js
@@ -15,15 +15,32 @@ export class ExecutionQueue {
    * Reads the hero's current state from GameStateManager before each step so
    * that state accumulated across ticks is always respected.
    *
-   * Halts immediately if an `andar` action would move the hero outside the grid.
+   * Halts and resets the hero if an `andar` action would move into an obstacle.
+   * Halts if the hero would leave the grid.
+   * After the final action, checks if the hero reached the goal and calls the
+   * appropriate callback.
    *
-   * @param {Array<{action: string}>} actions - Parsed action array from CommandParser.
-   * @param {number} gridSize - Number of cells per side of the grid.
-   * @param {number} [tickMs=500] - Milliseconds between ticks.
+   * @param {Array<{action: string}>} actions  - Parsed action array from CommandParser.
+   * @param {object}                  nivel    - Loaded level data (gridSize, goal, obstacles).
+   * @param {number}                  [tickMs=500] - Milliseconds between ticks.
+   * @param {Function}                [onSuccess]  - Called when the hero reaches the goal.
+   * @param {Function}                [onFailure]  - Called when the hero collides with an obstacle.
    */
-  startTickLoop(actions, gridSize, tickMs = 500) {
+  startTickLoop(actions, nivel, tickMs = 500, onSuccess, onFailure) {
+    const { gridSize, goal, obstacles } = nivel;
+
+    // Build a fast lookup set: "x,y" strings for O(1) collision tests
+    const obstacleSet = new Set(obstacles.map((o) => `${o.x},${o.y}`));
+
     const step = (index) => {
-      if (index >= actions.length) return;
+      if (index >= actions.length) {
+        // All actions consumed — check win condition
+        const { x, y } = gameStateManager.heroi;
+        if (x === goal.x && y === goal.y) {
+          onSuccess?.();
+        }
+        return;
+      }
 
       const { x, y, direcao } = gameStateManager.heroi;
       const { action } = actions[index];
@@ -38,8 +55,15 @@ export class ExecutionQueue {
         if (direcao === 'Sul')    newY = y + 1;
         if (direcao === 'Norte')  newY = y - 1;
 
-        // Stop the loop when the hero would leave the grid
+        // Halt if the hero would leave the grid
         if (newX < 0 || newX >= gridSize || newY < 0 || newY >= gridSize) return;
+
+        // Halt and reset if the hero would enter an obstacle cell
+        if (obstacleSet.has(`${newX},${newY}`)) {
+          gameStateManager.resetHeroi();
+          onFailure?.();
+          return;
+        }
       } else if (action === 'virarDireita') {
         newDirecao = TURN_RIGHT[direcao];
       } else if (action === 'virarEsquerda') {

--- a/src/services/GridRenderer.js
+++ b/src/services/GridRenderer.js
@@ -9,6 +9,12 @@ export class GridRenderer {
   /** Border color for each cell */
   static CELL_BORDER = '#CCCCCC';
 
+  /** Fill color for obstacle cells */
+  static OBSTACLE_COLOR = '#424242';
+
+  /** Fill color for the goal cell */
+  static GOAL_COLOR = '#4CAF50';
+
   /**
    * Renders the full grid onto the given Canvas 2D context.
    *
@@ -16,8 +22,10 @@ export class GridRenderer {
    * @param {number}                  tamanhoDoGrid   - Number of cells per side (e.g. 5 → 5×5 grid).
    * @param {number}                  tamanhoDaCelula - Pixel size of each individual cell.
    * @param {import('../models/Entity').Entity|null} heroi - Hero entity to draw, or null to skip.
+   * @param {object|null} nivel        - Loaded level data (obstacles, goal), or null.
+   * @param {boolean}     blinkVisible - Whether the goal is visible in the current blink frame.
    */
-  renderGrid(ctx, tamanhoDoGrid, tamanhoDaCelula, heroi = null) {
+  renderGrid(ctx, tamanhoDoGrid, tamanhoDaCelula, heroi = null, nivel = null, blinkVisible = true) {
     const totalSize = tamanhoDoGrid * tamanhoDaCelula;
 
     // Clear the canvas area that the grid will occupy
@@ -39,9 +47,54 @@ export class GridRenderer {
       }
     }
 
+    if (nivel) {
+      this._drawObstacles(ctx, nivel.obstacles, tamanhoDaCelula);
+      this._drawGoal(ctx, nivel.goal, tamanhoDaCelula, blinkVisible);
+    }
+
     if (heroi) {
       this._drawHeroi(ctx, heroi, tamanhoDaCelula);
     }
+  }
+
+  /**
+   * Draws each obstacle cell as a solid dark-gray square.
+   *
+   * @param {CanvasRenderingContext2D} ctx
+   * @param {Array<{x: number, y: number}>} obstacles
+   * @param {number} tamanhoDaCelula
+   */
+  _drawObstacles(ctx, obstacles, tamanhoDaCelula) {
+    ctx.fillStyle = GridRenderer.OBSTACLE_COLOR;
+    for (const obs of obstacles) {
+      ctx.fillRect(
+        obs.x * tamanhoDaCelula,
+        obs.y * tamanhoDaCelula,
+        tamanhoDaCelula,
+        tamanhoDaCelula
+      );
+    }
+  }
+
+  /**
+   * Draws the goal cell as a green square with a small inset padding.
+   * When blinkVisible is false the cell is skipped, producing a blink effect.
+   *
+   * @param {CanvasRenderingContext2D} ctx
+   * @param {{x: number, y: number}} goal
+   * @param {number} tamanhoDaCelula
+   * @param {boolean} blinkVisible
+   */
+  _drawGoal(ctx, goal, tamanhoDaCelula, blinkVisible) {
+    if (!blinkVisible) return;
+    const padding = tamanhoDaCelula * 0.1;
+    ctx.fillStyle = GridRenderer.GOAL_COLOR;
+    ctx.fillRect(
+      goal.x * tamanhoDaCelula + padding,
+      goal.y * tamanhoDaCelula + padding,
+      tamanhoDaCelula - padding * 2,
+      tamanhoDaCelula - padding * 2
+    );
   }
 
   /**

--- a/src/stores/GameStateManager.js
+++ b/src/stores/GameStateManager.js
@@ -11,6 +11,9 @@ class GameStateManager {
     /** @type {Entity} The player-controlled hero. */
     this.heroi = new Entity('heroi', 0, 0, 'Leste', '#4A90D9');
 
+    /** @type {object|null} The currently loaded level, or null if none. */
+    this.nivel = null;
+
     /** @type {Set<Function>} Registered listener callbacks. */
     this._listeners = new Set();
   }
@@ -25,6 +28,37 @@ class GameStateManager {
   subscribe(callback) {
     this._listeners.add(callback);
     return () => this._listeners.delete(callback);
+  }
+
+  /**
+   * Load a level: positions the hero at the level's start cell and stores
+   * the level data so other systems (renderer, execution queue) can access it.
+   *
+   * @param {object} nivel - Level definition from levels.js.
+   */
+  loadLevel(nivel) {
+    this.nivel = nivel;
+    this.heroi = new Entity(
+      'heroi',
+      nivel.start.x,
+      nivel.start.y,
+      nivel.start.dir,
+      '#4A90D9'
+    );
+    this._notify();
+  }
+
+  /**
+   * Reset the hero to the loaded level's start position and direction.
+   * Does nothing if no level is loaded.
+   */
+  resetHeroi() {
+    if (!this.nivel) return;
+    this.moverHeroi({
+      x: this.nivel.start.x,
+      y: this.nivel.start.y,
+      direcao: this.nivel.start.dir,
+    });
   }
 
   /**


### PR DESCRIPTION
## Descrição

Este PR foi gerado automaticamente pelo **Hephaestus** para resolver a Issue #5.

**Agente executor:** Claude Code
**Workflow Run:** `7dc378b3-4e75-443e-a55c-69625e7f3756`

## Changelog

All done. Here's a summary of every change made:
---
### New file: `src/levels/levels.js`
Defines the level schema and exports `levels[]`. Level 1 is a 5×5 grid, hero starts at (0,0) facing East, goal at (4,4), with two obstacles at (2,2) and (2,3).
### `GameStateManager.js`
- Added `this.nivel = null` field.
- `loadLevel(nivel)` — stores the level, recreates the hero at `nivel.start`, notifies subscribers.
- `resetHeroi()` — restores hero to `nivel.start` position/direction via `moverHeroi`.
### `GridRenderer.js`
- `renderGrid` now accepts `nivel` and `blinkVisible` params.
- `_drawObstacles()` — fills each obstacle cell with dark gray (`#424242`).
- `_drawGoal()` — fills the goal cell with green (`#4CAF50`) with a small inset; skipped entirely when `blinkVisible` is false, producing the blink.
### `ExecutionQueue.js`
- `startTickLoop` now accepts `nivel`, `onSuccess`, `onFailure` instead of bare `gridSize`.
- Builds an `obstacleSet` (`Set<"x,y">`) for O(1) collision lookup.
- On obstacle collision: calls `gameStateManager.resetHeroi()` then `onFailure()`.
- After the last action: checks if hero is on the goal cell and calls `onSuccess()` if so.
### `GameControlButtons.js`
- Now accepts `nivel`, `onSuccess`, `onFailure` props (replacing `gridSize`).
- Passes all three through to `startTickLoop`.
### `Grid.js`
- Loads `levels[0]` via `gameStateManager.loadLevel()` at module init.
- `blinkVisible` state toggles every 500 ms via `setInterval`, driving goal blink.
- `gameResult` state (`'success' | 'failure' | null`) shows colored status messages in the sidebar.
- Passes `NIVEL` and `blinkVisible` to `renderGrid`; passes `NIVEL` and callbacks to `GameControlButtons`.

---
Closes #5