### PR TITLE
feat(issue-6): github:6

### DIFF
--- a/src/components/CommandInput.js
+++ b/src/components/CommandInput.js
@@ -36,7 +36,7 @@ function CommandInput({ onExecute }) {
         style={styles.textarea}
         value={text}
         onChange={(e) => setText(e.target.value)}
-        placeholder={'andar()\nvirarDireita()\nandar()'}
+        placeholder={'repetir(4) {\n  andar()\n  virarDireita()\n}'}
         rows={10}
         spellCheck={false}
       />

--- a/src/services/CommandParser.js
+++ b/src/services/CommandParser.js
@@ -3,53 +3,136 @@
  * Parses a multi-line string of commands into an array of action objects.
  *
  * Supported commands: andar(), virarDireita(), virarEsquerda()
- * Whitespace and blank lines are ignored.
- * Throws a SyntaxError on the first unrecognised command, stopping the parse.
+ * Supported structures: repetir(n) { ... }  (nestable)
+ * Whitespace, blank lines, and semicolons are handled gracefully.
+ * Throws a SyntaxError on the first unrecognised command or malformed block.
  */
 
 const VALID_COMMANDS = new Set(['andar', 'virarDireita', 'virarEsquerda']);
 
-// Matches an identifier followed by ()  — e.g. "andar()" or "  virarDireita() "
-const COMMAND_RE = /^\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\(\s*\)\s*$/;
+// Matches a simple command identifier followed by ()
+const COMMAND_RE = /^([a-zA-Z_][a-zA-Z0-9_]*)\s*\(\s*\)$/;
+
+// Matches a repetir header: repetir(n) — n must be a non-negative integer
+const REPETIR_RE = /^repetir\s*\(\s*(\d+)\s*\)$/;
 
 export class CommandParser {
   /**
-   * Parse a string of commands.
+   * Parse a string of commands, including repetir(n) { ... } blocks.
    *
    * @param {string} text - Raw input from the textarea.
-   * @returns {{ action: string }[]} Array of action objects.
-   * @throws {SyntaxError} If an unrecognised command is found.
+   * @returns {Array<{action: string} | {action: 'repetir', count: number, commands: Array}>}
+   * @throws {SyntaxError} If an unrecognised command or malformed block is found.
    */
   parseCommands(text) {
-    const actions = [];
+    const tokens = this._tokenize(text);
+    const { commands, consumed } = this._parseBlock(tokens, 0, false);
 
-    const lines = text.split(/\r?\n/);
-
-    for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
-      const line = lines[lineIndex];
-
-      // Skip blank / whitespace-only lines
-      if (line.trim() === '') continue;
-
-      const match = COMMAND_RE.exec(line);
-
-      if (!match) {
-        throw new SyntaxError(
-          `Erro de sintaxe na linha ${lineIndex + 1}: "${line.trim()}"`
-        );
-      }
-
-      const commandName = match[1];
-
-      if (!VALID_COMMANDS.has(commandName)) {
-        throw new SyntaxError(
-          `Comando desconhecido na linha ${lineIndex + 1}: "${commandName}()"`
-        );
-      }
-
-      actions.push({ action: commandName });
+    if (consumed < tokens.length) {
+      throw new SyntaxError(
+        `Erro de sintaxe: "}" inesperado (bloco não aberto)`
+      );
     }
 
-    return actions;
+    return commands;
+  }
+
+  /**
+   * Tokenize the raw input into an array of string tokens.
+   * Braces and semicolons are treated as separators so that inline syntax like
+   * `repetir(4) { andar(); virarDireita(); }` is parsed correctly.
+   *
+   * @param {string} text
+   * @returns {string[]}
+   */
+  _tokenize(text) {
+    // Pad { and } with spaces so they become isolated tokens after splitting
+    const spaced = text.replace(/\{/g, ' { ').replace(/\}/g, ' } ');
+    // Split on whitespace, newlines, and semicolons; drop empty strings
+    return spaced
+      .split(/[\s;]+/)
+      .map((t) => t.trim())
+      .filter((t) => t !== '');
+  }
+
+  /**
+   * Recursively parse a sequence of tokens into a command array.
+   * Stops when it encounters "}" (if inside a block) or runs out of tokens.
+   *
+   * @param {string[]} tokens
+   * @param {number}   start       - Token index to start from.
+   * @param {boolean}  insideBlock - Whether we are inside a repetir { } block.
+   * @returns {{ commands: Array, consumed: number }}
+   */
+  _parseBlock(tokens, start, insideBlock) {
+    const commands = [];
+    let i = start;
+
+    while (i < tokens.length) {
+      const token = tokens[i];
+
+      if (token === '{') {
+        throw new SyntaxError(
+          `Erro de sintaxe: "{" inesperado sem comando "repetir"`
+        );
+      }
+
+      if (token === '}') {
+        if (!insideBlock) {
+          // Let the caller detect the stray brace via leftover consumed count
+          break;
+        }
+        // Consume the closing brace and return
+        return { commands, consumed: i - start + 1 };
+      }
+
+      // repetir(n) header
+      const repetirMatch = REPETIR_RE.exec(token);
+      if (repetirMatch) {
+        const count = parseInt(repetirMatch[1], 10);
+
+        // Expect "{" as the very next token
+        i++;
+        if (i >= tokens.length || tokens[i] !== '{') {
+          throw new SyntaxError(
+            `Erro de sintaxe: esperado "{" após "repetir(${count})"`
+          );
+        }
+        i++; // consume "{"
+
+        const inner = this._parseBlock(tokens, i, true);
+        // _parseBlock throws if it hits EOF without "}" when insideBlock=true,
+        // so reaching here means it found the closing brace.
+        commands.push({ action: 'repetir', count, commands: inner.commands });
+        i += inner.consumed;
+        continue;
+      }
+
+      // Simple command
+      const cmdMatch = COMMAND_RE.exec(token);
+      if (!cmdMatch) {
+        throw new SyntaxError(
+          `Erro de sintaxe: token desconhecido "${token}"`
+        );
+      }
+
+      const commandName = cmdMatch[1];
+      if (!VALID_COMMANDS.has(commandName)) {
+        throw new SyntaxError(
+          `Comando desconhecido: "${commandName}()"`
+        );
+      }
+
+      commands.push({ action: commandName });
+      i++;
+    }
+
+    if (insideBlock) {
+      throw new SyntaxError(
+        `Erro de sintaxe: bloco "repetir" não foi fechado com "}"`
+      );
+    }
+
+    return { commands, consumed: i - start };
   }
 }

--- a/src/services/CommandParser.test.js
+++ b/src/services/CommandParser.test.js
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest';
+import { CommandParser } from './CommandParser';
+
+const parser = new CommandParser();
+
+// ---------------------------------------------------------------------------
+// Simple commands (regression — existing behaviour must still work)
+// ---------------------------------------------------------------------------
+describe('CommandParser — simple commands', () => {
+  it('parses a single andar()', () => {
+    expect(parser.parseCommands('andar()')).toEqual([{ action: 'andar' }]);
+  });
+
+  it('parses multiple commands separated by newlines', () => {
+    const result = parser.parseCommands('andar()\nvirarDireita()\nvirarEsquerda()');
+    expect(result).toEqual([
+      { action: 'andar' },
+      { action: 'virarDireita' },
+      { action: 'virarEsquerda' },
+    ]);
+  });
+
+  it('ignores blank lines', () => {
+    expect(parser.parseCommands('\n\nandar()\n\n')).toEqual([{ action: 'andar' }]);
+  });
+
+  it('handles commands separated by semicolons', () => {
+    expect(parser.parseCommands('andar(); virarDireita()')).toEqual([
+      { action: 'andar' },
+      { action: 'virarDireita' },
+    ]);
+  });
+
+  it('throws SyntaxError for unknown command', () => {
+    expect(() => parser.parseCommands('pular()')).toThrow(SyntaxError);
+    expect(() => parser.parseCommands('pular()')).toThrow('pular()');
+  });
+
+  it('throws SyntaxError for malformed token', () => {
+    expect(() => parser.parseCommands('andar')).toThrow(SyntaxError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// repetir blocks
+// ---------------------------------------------------------------------------
+describe('CommandParser — repetir(n) { ... }', () => {
+  it('parses a single repetir block (inline)', () => {
+    const result = parser.parseCommands('repetir(3) { andar() }');
+    expect(result).toEqual([
+      {
+        action: 'repetir',
+        count: 3,
+        commands: [{ action: 'andar' }],
+      },
+    ]);
+  });
+
+  it('parses a repetir block with multiple inner commands', () => {
+    const result = parser.parseCommands('repetir(4) { andar(); virarDireita() }');
+    expect(result).toEqual([
+      {
+        action: 'repetir',
+        count: 4,
+        commands: [{ action: 'andar' }, { action: 'virarDireita' }],
+      },
+    ]);
+  });
+
+  it('parses a repetir block spread across multiple lines', () => {
+    const input = `repetir(2) {\n  andar()\n  virarEsquerda()\n}`;
+    const result = parser.parseCommands(input);
+    expect(result).toEqual([
+      {
+        action: 'repetir',
+        count: 2,
+        commands: [{ action: 'andar' }, { action: 'virarEsquerda' }],
+      },
+    ]);
+  });
+
+  it('parses nested repetir blocks', () => {
+    const input = 'repetir(2) { repetir(3) { andar() } }';
+    const result = parser.parseCommands(input);
+    expect(result).toEqual([
+      {
+        action: 'repetir',
+        count: 2,
+        commands: [
+          {
+            action: 'repetir',
+            count: 3,
+            commands: [{ action: 'andar' }],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('parses commands before and after a repetir block', () => {
+    const input = 'andar()\nrepetir(2) { virarDireita() }\nandar()';
+    const result = parser.parseCommands(input);
+    expect(result).toEqual([
+      { action: 'andar' },
+      { action: 'repetir', count: 2, commands: [{ action: 'virarDireita' }] },
+      { action: 'andar' },
+    ]);
+  });
+
+  it('parses repetir(0) with empty result (no iterations)', () => {
+    const result = parser.parseCommands('repetir(0) { andar() }');
+    expect(result).toEqual([
+      { action: 'repetir', count: 0, commands: [{ action: 'andar' }] },
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error cases
+// ---------------------------------------------------------------------------
+describe('CommandParser — error cases', () => {
+  it('throws SyntaxError when repetir block is not closed', () => {
+    expect(() => parser.parseCommands('repetir(2) { andar()')).toThrow(SyntaxError);
+    expect(() => parser.parseCommands('repetir(2) { andar()')).toThrow('não foi fechado');
+  });
+
+  it('throws SyntaxError when "{" appears without repetir', () => {
+    expect(() => parser.parseCommands('{ andar() }')).toThrow(SyntaxError);
+    expect(() => parser.parseCommands('{ andar() }')).toThrow('"{"');
+  });
+
+  it('throws SyntaxError for stray closing brace', () => {
+    expect(() => parser.parseCommands('andar() }')).toThrow(SyntaxError);
+    expect(() => parser.parseCommands('andar() }')).toThrow('"}"');
+  });
+
+  it('throws SyntaxError when repetir is missing opening brace', () => {
+    expect(() => parser.parseCommands('repetir(2) andar()')).toThrow(SyntaxError);
+    expect(() => parser.parseCommands('repetir(2) andar()')).toThrow('esperado "{"');
+  });
+
+  it('throws SyntaxError for unknown command inside a block', () => {
+    expect(() => parser.parseCommands('repetir(2) { pular() }')).toThrow(SyntaxError);
+    expect(() => parser.parseCommands('repetir(2) { pular() }')).toThrow('pular()');
+  });
+});

--- a/src/services/ExecutionQueue.js
+++ b/src/services/ExecutionQueue.js
@@ -8,8 +8,32 @@ const TURN_LEFT  = { Norte: 'Oeste', Oeste: 'Sul', Sul: 'Leste', Leste: 'Norte' 
  * Executes an array of parsed actions one at a time, with a fixed delay between
  * each step, updating GameStateManager after every action so the canvas redraws
  * incrementally (tick-based animation).
+ *
+ * Supports repetir(n) { ... } blocks by flattening them into a linear action
+ * list before execution begins, so the tick loop stays simple and non-blocking.
  */
 export class ExecutionQueue {
+  /**
+   * Recursively flatten a (possibly nested) action tree into a plain array of
+   * simple actions. repetir nodes are expanded inline.
+   *
+   * @param {Array} actions - Output of CommandParser.parseCommands().
+   * @returns {Array<{action: string}>} Flat list of simple action objects.
+   */
+  flattenActions(actions) {
+    const flat = [];
+    for (const item of actions) {
+      if (item.action === 'repetir') {
+        for (let i = 0; i < item.count; i++) {
+          flat.push(...this.flattenActions(item.commands));
+        }
+      } else {
+        flat.push(item);
+      }
+    }
+    return flat;
+  }
+
   /**
    * Start the tick loop for the given action list.
    * Reads the hero's current state from GameStateManager before each step so
@@ -20,20 +44,23 @@ export class ExecutionQueue {
    * After the final action, checks if the hero reached the goal and calls the
    * appropriate callback.
    *
-   * @param {Array<{action: string}>} actions  - Parsed action array from CommandParser.
-   * @param {object}                  nivel    - Loaded level data (gridSize, goal, obstacles).
-   * @param {number}                  [tickMs=500] - Milliseconds between ticks.
-   * @param {Function}                [onSuccess]  - Called when the hero reaches the goal.
-   * @param {Function}                [onFailure]  - Called when the hero collides with an obstacle.
+   * @param {Array}    actions      - Parsed action array from CommandParser (may contain repetir nodes).
+   * @param {object}   nivel        - Loaded level data (gridSize, goal, obstacles).
+   * @param {number}   [tickMs=500] - Milliseconds between ticks.
+   * @param {Function} [onSuccess]  - Called when the hero reaches the goal.
+   * @param {Function} [onFailure]  - Called when the hero collides with an obstacle.
    */
   startTickLoop(actions, nivel, tickMs = 500, onSuccess, onFailure) {
     const { gridSize, goal, obstacles } = nivel;
+
+    // Expand repetir blocks into a flat sequence before the tick loop starts
+    const flatActions = this.flattenActions(actions);
 
     // Build a fast lookup set: "x,y" strings for O(1) collision tests
     const obstacleSet = new Set(obstacles.map((o) => `${o.x},${o.y}`));
 
     const step = (index) => {
-      if (index >= actions.length) {
+      if (index >= flatActions.length) {
         // All actions consumed — check win condition
         const { x, y } = gameStateManager.heroi;
         if (x === goal.x && y === goal.y) {
@@ -43,7 +70,7 @@ export class ExecutionQueue {
       }
 
       const { x, y, direcao } = gameStateManager.heroi;
-      const { action } = actions[index];
+      const { action } = flatActions[index];
 
       let newX = x;
       let newY = y;

--- a/src/services/ExecutionQueue.test.js
+++ b/src/services/ExecutionQueue.test.js
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { ExecutionQueue } from './ExecutionQueue';
+
+const queue = new ExecutionQueue();
+
+// ---------------------------------------------------------------------------
+// flattenActions
+// ---------------------------------------------------------------------------
+describe('ExecutionQueue.flattenActions', () => {
+  it('returns simple actions unchanged', () => {
+    const actions = [{ action: 'andar' }, { action: 'virarDireita' }];
+    expect(queue.flattenActions(actions)).toEqual(actions);
+  });
+
+  it('expands a repetir(3) block into 3 copies of its inner commands', () => {
+    const actions = [
+      { action: 'repetir', count: 3, commands: [{ action: 'andar' }] },
+    ];
+    expect(queue.flattenActions(actions)).toEqual([
+      { action: 'andar' },
+      { action: 'andar' },
+      { action: 'andar' },
+    ]);
+  });
+
+  it('expands repetir(4) { andar(); virarDireita() } into 8 actions', () => {
+    const actions = [
+      {
+        action: 'repetir',
+        count: 4,
+        commands: [{ action: 'andar' }, { action: 'virarDireita' }],
+      },
+    ];
+    const flat = queue.flattenActions(actions);
+    expect(flat).toHaveLength(8);
+    // Pattern should repeat: andar, virarDireita x4
+    for (let i = 0; i < 4; i++) {
+      expect(flat[i * 2]).toEqual({ action: 'andar' });
+      expect(flat[i * 2 + 1]).toEqual({ action: 'virarDireita' });
+    }
+  });
+
+  it('expands nested repetir blocks correctly', () => {
+    // repetir(2) { repetir(3) { andar() } } => 6x andar
+    const actions = [
+      {
+        action: 'repetir',
+        count: 2,
+        commands: [
+          {
+            action: 'repetir',
+            count: 3,
+            commands: [{ action: 'andar' }],
+          },
+        ],
+      },
+    ];
+    const flat = queue.flattenActions(actions);
+    expect(flat).toHaveLength(6);
+    expect(flat.every((a) => a.action === 'andar')).toBe(true);
+  });
+
+  it('returns empty array for repetir(0)', () => {
+    const actions = [
+      { action: 'repetir', count: 0, commands: [{ action: 'andar' }] },
+    ];
+    expect(queue.flattenActions(actions)).toEqual([]);
+  });
+
+  it('handles mixed simple and repetir actions', () => {
+    const actions = [
+      { action: 'andar' },
+      { action: 'repetir', count: 2, commands: [{ action: 'virarDireita' }] },
+      { action: 'andar' },
+    ];
+    expect(queue.flattenActions(actions)).toEqual([
+      { action: 'andar' },
+      { action: 'virarDireita' },
+      { action: 'virarDireita' },
+      { action: 'andar' },
+    ]);
+  });
+
+  it('produces the correct sequence for a perfect square path', () => {
+    // repetir(4) { andar(); virarDireita() } should trace a square
+    const actions = [
+      {
+        action: 'repetir',
+        count: 4,
+        commands: [{ action: 'andar' }, { action: 'virarDireita' }],
+      },
+    ];
+    const flat = queue.flattenActions(actions);
+    expect(flat).toHaveLength(8);
+    const expected = Array.from({ length: 4 }, () => [
+      { action: 'andar' },
+      { action: 'virarDireita' },
+    ]).flat();
+    expect(flat).toEqual(expected);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  test: {
+    name: 'logic-grid',
+    watch: false,
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{js,mjs,ts,jsx,tsx}'],
+    reporters: ['default'],
+    passWithNoTests: true,
+  },
+});


### PR DESCRIPTION
## Descrição

Este PR foi gerado automaticamente pelo **Hephaestus** para resolver a Issue #6.

**Agente executor:** Claude Code
**Workflow Run:** `5d0b5c58-cf8c-4a8c-a6b3-cd75bb8816f4`

## Changelog

24/24 tests passing. Here's the summary:
---
## O que foi feito
### Arquivos alterados
#### `src/services/CommandParser.js`
**Substituição completa da lógica de parsing.**
- Removido: parsing linha a linha via `text.split(/\r?\n/)` e regex `COMMAND_RE` com `^\s*...\s*$`. Essa abordagem não conseguia lidar com blocos multi-linha ou tokens inline separados por `;` e `{}`.
- Adicionado: método `_tokenize()` que normaliza a entrada inserindo espaços em torno de `{` e `}`, depois divide por whitespace e `;` — produzindo tokens atômicos independente do estilo do usuário (inline ou multiline).
- Adicionado: método `_parseBlock()` recursivo que processa a lista de tokens com uma pilha implícita via recursão, suportando aninhamento arbitrário de `repetir`.
- Adicionado: regex `REPETIR_RE` para identificar o cabeçalho `repetir(n)`.
- Erros específicos lançados:
  - `"}" inesperado (bloco não aberto)` — chave extra sem `repetir`
  - `esperado "{" após "repetir(n)"` — falta abertura de bloco
  - `bloco "repetir" não foi fechado com "}"` — falta fechamento
#### `src/services/ExecutionQueue.js`
- Adicionado: método público `flattenActions(actions)` que percorre recursivamente a árvore de ações e expande cada nó `repetir` em `count` cópias de seus filhos — produzindo um array plano de ações simples.
- Modificado: `startTickLoop` agora chama `this.flattenActions(actions)` antes de iniciar o tick loop, mantendo toda a lógica de animação existente intacta e sem necessitar processar recursão durante a execução.
- **Motivo técnico**: ao achatar antes da execução, os `setTimeout` recursivos não acumulam profundidade de pilha nem bloqueiam a thread principal, independente do número de iterações.
#### `src/components/CommandInput.js`
- Atualizado: `placeholder` da textarea para mostrar um exemplo com `repetir(4) { ... }`, ajudando o usuário a descobrir a nova sintaxe.
### Arquivos criados
#### `vitest.config.ts` (raiz)
Config mínima para rodar os testes do jogo via `vitest run`, apontando para `src/**/*.test.{js,...}`. Integra-se ao `vitest.workspace.ts` existente.
#### `src/services/CommandParser.test.js`
17 testes cobrindo: comandos simples (regressão), blocos `repetir` inline e multiline, aninhamento, `repetir(0)`, comandos antes/depois do bloco, e todos os caminhos de erro.
#### `src/services/ExecutionQueue.test.js`
7 testes cobrindo: ações simples sem alteração, expansão de `repetir(n)`, blocos aninhados, `repetir(0)`, mistura de simples e repetir, e validação do caminho quadrado perfeito (`repetir(4) { andar(); virarDireita() }`).
**Resultado: 24/24 testes passando.**

---
Closes #6