### PR TITLE
feat(issue-7): github:7

### DIFF
--- a/src/components/CommandInput.js
+++ b/src/components/CommandInput.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
-import { CommandParser } from '../services/CommandParser';
+import { ConditionalCommandParser } from '../services/ConditionalCommandParser';
 
-const parser = new CommandParser();
+const parser = new ConditionalCommandParser();
 
 /**
  * CommandInput
@@ -36,7 +36,7 @@ function CommandInput({ onExecute }) {
         style={styles.textarea}
         value={text}
         onChange={(e) => setText(e.target.value)}
-        placeholder={'repetir(4) {\n  andar()\n  virarDireita()\n}'}
+        placeholder={'se (caminhoLivre()) {\n  andar()\n} senao {\n  virarDireita()\n}'}
         rows={10}
         spellCheck={false}
       />

--- a/src/services/CommandParser.js
+++ b/src/services/CommandParser.js
@@ -6,6 +6,9 @@
  * Supported structures: repetir(n) { ... }  (nestable)
  * Whitespace, blank lines, and semicolons are handled gracefully.
  * Throws a SyntaxError on the first unrecognised command or malformed block.
+ *
+ * Subclasses may extend _tryParseCustomToken() to add support for additional
+ * block-level constructs (e.g. se/senao conditional commands).
  */
 
 const VALID_COMMANDS = new Set(['andar', 'virarDireita', 'virarEsquerda']);
@@ -73,7 +76,7 @@ export class CommandParser {
 
       if (token === '{') {
         throw new SyntaxError(
-          `Erro de sintaxe: "{" inesperado sem comando "repetir"`
+          `Erro de sintaxe: "{" inesperado sem comando de bloco`
         );
       }
 
@@ -108,6 +111,15 @@ export class CommandParser {
         continue;
       }
 
+      // Hook: give subclasses the opportunity to parse custom block constructs
+      // (e.g. se/senao).  Returns {command, newIndex} or null.
+      const customResult = this._tryParseCustomToken(tokens, i);
+      if (customResult !== null) {
+        if (customResult.command != null) commands.push(customResult.command);
+        i = customResult.newIndex;
+        continue;
+      }
+
       // Simple command
       const cmdMatch = COMMAND_RE.exec(token);
       if (!cmdMatch) {
@@ -134,5 +146,21 @@ export class CommandParser {
     }
 
     return { commands, consumed: i - start };
+  }
+
+  /**
+   * Extension hook called by _parseBlock for any token that does not match
+   * a brace, repetir, or simple command.
+   *
+   * Subclasses override this to handle custom constructs (e.g. se/senao).
+   * The base implementation always returns null, causing the caller to fall
+   * through to the "unknown token" SyntaxError.
+   *
+   * @param {string[]} tokens - Full token array.
+   * @param {number}   i      - Index of the current token.
+   * @returns {{ command: object|null, newIndex: number } | null}
+   */
+  _tryParseCustomToken(_tokens, _i) {
+    return null;
   }
 }

--- a/src/services/ConditionalCommandParser.js
+++ b/src/services/ConditionalCommandParser.js
@@ -1,0 +1,115 @@
+import { CommandParser } from './CommandParser';
+
+/**
+ * Known sensor function names accepted inside se(...) conditions.
+ */
+const SENSOR_COMMANDS = new Set(['caminhoLivre', 'sobreObjetivo', 'temParede']);
+
+/**
+ * Matches a fully-merged se token: se(sensorName()) — produced by _tokenize.
+ * Capture group 1 is the sensor function name.
+ */
+const SE_RE = /^se\s*\(\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\(\s*\)\s*\)$/;
+
+/**
+ * ConditionalCommandParser
+ * Extends CommandParser to support the conditional construct:
+ *
+ *   se (sensorFn()) { comandos }
+ *   se (sensorFn()) { comandos } senao { comandos }
+ *
+ * Sensor functions: caminhoLivre(), sobreObjetivo(), temParede()
+ *
+ * Parsed output for a se node:
+ *   { action: 'se', condition: string, commands: Array, elseCommands?: Array }
+ *
+ * Conditions are NOT evaluated here — evaluation happens at tick time in
+ * ExecutionQueue using SensorService.
+ */
+export class ConditionalCommandParser extends CommandParser {
+  /**
+   * Override tokenizer to merge a bare 'se' token with the immediately
+   * following '(...)' token so that both `se(cond())` and `se (cond())`
+   * produce the same single token that SE_RE can match.
+   *
+   * @param {string} text
+   * @returns {string[]}
+   */
+  _tokenize(text) {
+    const tokens = super._tokenize(text);
+    const merged = [];
+    for (let i = 0; i < tokens.length; i++) {
+      if (tokens[i] === 'se' && i + 1 < tokens.length && tokens[i + 1].startsWith('(')) {
+        merged.push(`se${tokens[i + 1]}`);
+        i++; // skip the '(...)' token — already merged
+      } else {
+        merged.push(tokens[i]);
+      }
+    }
+    return merged;
+  }
+
+  /**
+   * Handle se(condition) { ... } [senao { ... }] constructs.
+   *
+   * Called by CommandParser._parseBlock for any token that does not match a
+   * brace, repetir, or simple command.
+   *
+   * @param {string[]} tokens
+   * @param {number}   i - Index of the current token.
+   * @returns {{ command: object, newIndex: number } | null}
+   */
+  _tryParseCustomToken(tokens, i) {
+    const token = tokens[i];
+
+    // ── se (condition) { ... } [senao { ... }] ───────────────────────────────
+    const seMatch = SE_RE.exec(token);
+    if (seMatch) {
+      const conditionName = seMatch[1];
+      if (!SENSOR_COMMANDS.has(conditionName)) {
+        throw new SyntaxError(`Sensor desconhecido: "${conditionName}()"`);
+      }
+
+      let j = i + 1;
+
+      // Expect opening brace
+      if (j >= tokens.length || tokens[j] !== '{') {
+        throw new SyntaxError(
+          `Erro de sintaxe: esperado "{" após "se(${conditionName}())"`
+        );
+      }
+      j++; // consume '{'
+
+      // Parse the then-branch
+      const inner = this._parseBlock(tokens, j, true);
+      j += inner.consumed;
+
+      const seCommand = {
+        action: 'se',
+        condition: conditionName,
+        commands: inner.commands,
+      };
+
+      // Optional senao branch
+      if (j < tokens.length && tokens[j] === 'senao') {
+        j++; // consume 'senao'
+        if (j >= tokens.length || tokens[j] !== '{') {
+          throw new SyntaxError(`Erro de sintaxe: esperado "{" após "senao"`);
+        }
+        j++; // consume '{'
+        const elseInner = this._parseBlock(tokens, j, true);
+        j += elseInner.consumed;
+        seCommand.elseCommands = elseInner.commands;
+      }
+
+      return { command: seCommand, newIndex: j };
+    }
+
+    // ── Stray 'senao' without a preceding 'se' ───────────────────────────────
+    if (token === 'senao') {
+      throw new SyntaxError(`Erro de sintaxe: "senao" sem "se" correspondente`);
+    }
+
+    return null;
+  }
+}

--- a/src/services/ConditionalCommandParser.test.js
+++ b/src/services/ConditionalCommandParser.test.js
@@ -1,0 +1,173 @@
+import { describe, it, expect } from 'vitest';
+import { ConditionalCommandParser } from './ConditionalCommandParser';
+
+const parser = new ConditionalCommandParser();
+
+// ---------------------------------------------------------------------------
+// Backward compatibility — existing commands must still parse correctly
+// ---------------------------------------------------------------------------
+describe('ConditionalCommandParser — backward compatibility', () => {
+  it('parses simple commands', () => {
+    expect(parser.parseCommands('andar()\nvirarDireita()\nvirarEsquerda()')).toEqual([
+      { action: 'andar' },
+      { action: 'virarDireita' },
+      { action: 'virarEsquerda' },
+    ]);
+  });
+
+  it('parses repetir blocks', () => {
+    expect(parser.parseCommands('repetir(3) { andar() }')).toEqual([
+      { action: 'repetir', count: 3, commands: [{ action: 'andar' }] },
+    ]);
+  });
+
+  it('throws SyntaxError for unknown commands', () => {
+    expect(() => parser.parseCommands('pular()')).toThrow(SyntaxError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// se — basic structure
+// ---------------------------------------------------------------------------
+describe('ConditionalCommandParser — se', () => {
+  it('parses se(caminhoLivre()) { andar() }', () => {
+    expect(parser.parseCommands('se(caminhoLivre()) { andar() }')).toEqual([
+      { action: 'se', condition: 'caminhoLivre', commands: [{ action: 'andar' }] },
+    ]);
+  });
+
+  it('parses se with a space before the condition: se (caminhoLivre())', () => {
+    expect(parser.parseCommands('se (caminhoLivre()) { andar() }')).toEqual([
+      { action: 'se', condition: 'caminhoLivre', commands: [{ action: 'andar' }] },
+    ]);
+  });
+
+  it('parses se(sobreObjetivo())', () => {
+    expect(parser.parseCommands('se(sobreObjetivo()) { virarDireita() }')).toEqual([
+      { action: 'se', condition: 'sobreObjetivo', commands: [{ action: 'virarDireita' }] },
+    ]);
+  });
+
+  it('parses se(temParede())', () => {
+    expect(parser.parseCommands('se(temParede()) { virarEsquerda() }')).toEqual([
+      { action: 'se', condition: 'temParede', commands: [{ action: 'virarEsquerda' }] },
+    ]);
+  });
+
+  it('parses se with multiple commands in then-branch', () => {
+    const result = parser.parseCommands('se(caminhoLivre()) { andar(); virarDireita() }');
+    expect(result).toEqual([
+      {
+        action: 'se',
+        condition: 'caminhoLivre',
+        commands: [{ action: 'andar' }, { action: 'virarDireita' }],
+      },
+    ]);
+  });
+
+  it('parses se spread across multiple lines', () => {
+    const input = `se (caminhoLivre()) {\n  andar()\n  virarEsquerda()\n}`;
+    const result = parser.parseCommands(input);
+    expect(result).toEqual([
+      {
+        action: 'se',
+        condition: 'caminhoLivre',
+        commands: [{ action: 'andar' }, { action: 'virarEsquerda' }],
+      },
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// se … senao
+// ---------------------------------------------------------------------------
+describe('ConditionalCommandParser — se/senao', () => {
+  it('parses se with a senao branch', () => {
+    const result = parser.parseCommands(
+      'se(caminhoLivre()) { andar() } senao { virarDireita() }'
+    );
+    expect(result).toEqual([
+      {
+        action: 'se',
+        condition: 'caminhoLivre',
+        commands: [{ action: 'andar' }],
+        elseCommands: [{ action: 'virarDireita' }],
+      },
+    ]);
+  });
+
+  it('parses se/senao multiline', () => {
+    const input = `se (temParede()) {\n  virarDireita()\n} senao {\n  andar()\n}`;
+    const result = parser.parseCommands(input);
+    expect(result).toEqual([
+      {
+        action: 'se',
+        condition: 'temParede',
+        commands: [{ action: 'virarDireita' }],
+        elseCommands: [{ action: 'andar' }],
+      },
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Nesting: se inside repetir
+// ---------------------------------------------------------------------------
+describe('ConditionalCommandParser — nesting', () => {
+  it('parses se nested inside repetir', () => {
+    const result = parser.parseCommands('repetir(2) { se(caminhoLivre()) { andar() } }');
+    expect(result).toEqual([
+      {
+        action: 'repetir',
+        count: 2,
+        commands: [
+          { action: 'se', condition: 'caminhoLivre', commands: [{ action: 'andar' }] },
+        ],
+      },
+    ]);
+  });
+
+  it('parses commands before and after a se block', () => {
+    const result = parser.parseCommands(
+      'virarDireita()\nse(caminhoLivre()) { andar() }\nvirarEsquerda()'
+    );
+    expect(result).toEqual([
+      { action: 'virarDireita' },
+      { action: 'se', condition: 'caminhoLivre', commands: [{ action: 'andar' }] },
+      { action: 'virarEsquerda' },
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error cases
+// ---------------------------------------------------------------------------
+describe('ConditionalCommandParser — error cases', () => {
+  it('throws SyntaxError for an unknown sensor inside se', () => {
+    expect(() => parser.parseCommands('se(voar()) { andar() }')).toThrow(SyntaxError);
+    expect(() => parser.parseCommands('se(voar()) { andar() }')).toThrow('voar');
+  });
+
+  it('throws SyntaxError when se is missing its opening brace', () => {
+    expect(() => parser.parseCommands('se(caminhoLivre()) andar()')).toThrow(SyntaxError);
+    expect(() => parser.parseCommands('se(caminhoLivre()) andar()')).toThrow('esperado "{"');
+  });
+
+  it('throws SyntaxError for an unclosed se block', () => {
+    expect(() => parser.parseCommands('se(caminhoLivre()) { andar()')).toThrow(SyntaxError);
+  });
+
+  it('throws SyntaxError when senao is missing its opening brace', () => {
+    expect(() =>
+      parser.parseCommands('se(caminhoLivre()) { andar() } senao andar()')
+    ).toThrow(SyntaxError);
+    expect(() =>
+      parser.parseCommands('se(caminhoLivre()) { andar() } senao andar()')
+    ).toThrow('esperado "{"');
+  });
+
+  it('throws SyntaxError for stray senao without se', () => {
+    expect(() => parser.parseCommands('senao { andar() }')).toThrow(SyntaxError);
+    expect(() => parser.parseCommands('senao { andar() }')).toThrow('senao');
+  });
+});

--- a/src/services/ExecutionQueue.js
+++ b/src/services/ExecutionQueue.js
@@ -1,4 +1,5 @@
 import { gameStateManager } from '../stores/GameStateManager';
+import { SensorService } from './SensorService';
 
 const TURN_RIGHT = { Norte: 'Leste', Leste: 'Sul', Sul: 'Oeste', Oeste: 'Norte' };
 const TURN_LEFT  = { Norte: 'Oeste', Oeste: 'Sul', Sul: 'Leste', Leste: 'Norte' };
@@ -10,15 +11,20 @@ const TURN_LEFT  = { Norte: 'Oeste', Oeste: 'Sul', Sul: 'Leste', Leste: 'Norte' 
  * incrementally (tick-based animation).
  *
  * Supports repetir(n) { ... } blocks by flattening them into a linear action
- * list before execution begins, so the tick loop stays simple and non-blocking.
+ * list before execution begins.
+ *
+ * Supports se(condition) { ... } [senao { ... }] blocks by evaluating the
+ * condition at the exact tick when that node is reached in the queue, so the
+ * decision always reflects the hero's live position at that moment.
  */
 export class ExecutionQueue {
   /**
-   * Recursively flatten a (possibly nested) action tree into a plain array of
-   * simple actions. repetir nodes are expanded inline.
+   * Recursively flatten a (possibly nested) action tree into a plain array.
+   * repetir nodes are expanded inline. se nodes are kept as-is so they can be
+   * evaluated at runtime during the tick loop.
    *
-   * @param {Array} actions - Output of CommandParser.parseCommands().
-   * @returns {Array<{action: string}>} Flat list of simple action objects.
+   * @param {Array} actions - Output of CommandParser / ConditionalCommandParser.
+   * @returns {Array} Flat list with repetir expanded and se nodes preserved.
    */
   flattenActions(actions) {
     const flat = [];
@@ -39,12 +45,17 @@ export class ExecutionQueue {
    * Reads the hero's current state from GameStateManager before each step so
    * that state accumulated across ticks is always respected.
    *
+   * se nodes are evaluated at the moment they reach the front of the execution
+   * queue: the correct branch is expanded inline and processed on subsequent
+   * ticks. This means the sensor reading is always based on the hero's actual
+   * position at that point in time.
+   *
    * Halts and resets the hero if an `andar` action would move into an obstacle.
-   * Halts if the hero would leave the grid.
+   * Halts silently if the hero would leave the grid.
    * After the final action, checks if the hero reached the goal and calls the
    * appropriate callback.
    *
-   * @param {Array}    actions      - Parsed action array from CommandParser (may contain repetir nodes).
+   * @param {Array}    actions      - Parsed action array (may contain repetir/se nodes).
    * @param {object}   nivel        - Loaded level data (gridSize, goal, obstacles).
    * @param {number}   [tickMs=500] - Milliseconds between ticks.
    * @param {Function} [onSuccess]  - Called when the hero reaches the goal.
@@ -52,16 +63,24 @@ export class ExecutionQueue {
    */
   startTickLoop(actions, nivel, tickMs = 500, onSuccess, onFailure) {
     const { gridSize, goal, obstacles } = nivel;
-
-    // Expand repetir blocks into a flat sequence before the tick loop starts
-    const flatActions = this.flattenActions(actions);
-
-    // Build a fast lookup set: "x,y" strings for O(1) collision tests
     const obstacleSet = new Set(obstacles.map((o) => `${o.x},${o.y}`));
+    const sensorService = new SensorService();
 
-    const step = (index) => {
-      if (index >= flatActions.length) {
-        // All actions consumed — check win condition
+    // Pre-expand repetir blocks; se nodes remain as lazy nodes for runtime eval
+    const queue = [...this.flattenActions(actions)];
+
+    const step = () => {
+      // Evaluate and expand any se nodes at the front of the queue.
+      // No tick delay is consumed: condition check is instantaneous.
+      while (queue.length > 0 && queue[0].action === 'se') {
+        const seNode = queue.shift();
+        const conditionResult = sensorService.evaluate(seNode.condition, nivel);
+        const branch = conditionResult ? seNode.commands : (seNode.elseCommands ?? []);
+        // Flatten repetir inside the chosen branch before inserting
+        queue.unshift(...this.flattenActions(branch));
+      }
+
+      if (queue.length === 0) {
         const { x, y } = gameStateManager.heroi;
         if (x === goal.x && y === goal.y) {
           onSuccess?.();
@@ -70,7 +89,7 @@ export class ExecutionQueue {
       }
 
       const { x, y, direcao } = gameStateManager.heroi;
-      const { action } = flatActions[index];
+      const { action } = queue.shift();
 
       let newX = x;
       let newY = y;
@@ -82,7 +101,7 @@ export class ExecutionQueue {
         if (direcao === 'Sul')    newY = y + 1;
         if (direcao === 'Norte')  newY = y - 1;
 
-        // Halt if the hero would leave the grid
+        // Halt silently if the hero would leave the grid
         if (newX < 0 || newX >= gridSize || newY < 0 || newY >= gridSize) return;
 
         // Halt and reset if the hero would enter an obstacle cell
@@ -98,9 +117,9 @@ export class ExecutionQueue {
       }
 
       gameStateManager.moverHeroi({ x: newX, y: newY, direcao: newDirecao });
-      setTimeout(() => step(index + 1), tickMs);
+      setTimeout(step, tickMs);
     };
 
-    step(0);
+    step();
   }
 }

--- a/src/services/SensorService.js
+++ b/src/services/SensorService.js
@@ -1,0 +1,74 @@
+import { gameStateManager } from '../stores/GameStateManager';
+
+/**
+ * SensorService
+ * Provides runtime sensor functions that query the current game state to allow
+ * the hero to "perceive" the map. All functions read the live state from
+ * GameStateManager so they reflect the hero's position at the exact moment
+ * they are called (i.e. at tick time).
+ */
+export class SensorService {
+  /**
+   * Returns true if the cell directly ahead of the hero is within the grid
+   * and contains no obstacle.
+   *
+   * @param {object} nivel - Loaded level data (gridSize, obstacles).
+   * @returns {boolean}
+   */
+  caminhoLivre(nivel) {
+    const { x, y, direcao } = gameStateManager.heroi;
+    const { gridSize, obstacles } = nivel;
+    const obstacleSet = new Set(obstacles.map((o) => `${o.x},${o.y}`));
+
+    let nx = x;
+    let ny = y;
+    if (direcao === 'Leste')  nx = x + 1;
+    if (direcao === 'Oeste')  nx = x - 1;
+    if (direcao === 'Sul')    ny = y + 1;
+    if (direcao === 'Norte')  ny = y - 1;
+
+    if (nx < 0 || nx >= gridSize || ny < 0 || ny >= gridSize) return false;
+    return !obstacleSet.has(`${nx},${ny}`);
+  }
+
+  /**
+   * Returns true if the hero's current cell matches the level's goal cell.
+   *
+   * @param {object} nivel - Loaded level data (goal).
+   * @returns {boolean}
+   */
+  sobreObjetivo(nivel) {
+    const { x, y } = gameStateManager.heroi;
+    const { goal } = nivel;
+    return x === goal.x && y === goal.y;
+  }
+
+  /**
+   * Returns true if the cell directly ahead is a wall (grid boundary) or
+   * an obstacle — i.e. the path is blocked.
+   *
+   * @param {object} nivel - Loaded level data.
+   * @returns {boolean}
+   */
+  temParede(nivel) {
+    return !this.caminhoLivre(nivel);
+  }
+
+  /**
+   * Evaluate a named sensor condition against the current game state.
+   *
+   * @param {string} conditionName - One of 'caminhoLivre', 'sobreObjetivo', 'temParede'.
+   * @param {object} nivel         - Loaded level data.
+   * @returns {boolean}
+   * @throws {Error} If the condition name is not recognised.
+   */
+  evaluate(conditionName, nivel) {
+    switch (conditionName) {
+      case 'caminhoLivre':  return this.caminhoLivre(nivel);
+      case 'sobreObjetivo': return this.sobreObjetivo(nivel);
+      case 'temParede':     return this.temParede(nivel);
+      default:
+        throw new Error(`Sensor desconhecido: "${conditionName}"`);
+    }
+  }
+}

--- a/src/services/SensorService.test.js
+++ b/src/services/SensorService.test.js
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SensorService } from './SensorService';
+import { gameStateManager } from '../stores/GameStateManager';
+
+const nivel = {
+  gridSize: 5,
+  start: { x: 2, y: 2, dir: 'Leste' },
+  goal: { x: 4, y: 4 },
+  obstacles: [{ x: 3, y: 2 }], // one cell east of start
+};
+
+const sensor = new SensorService();
+
+beforeEach(() => {
+  gameStateManager.loadLevel(nivel);
+});
+
+// ---------------------------------------------------------------------------
+// caminhoLivre
+// ---------------------------------------------------------------------------
+describe('SensorService.caminhoLivre', () => {
+  it('returns false when the cell ahead contains an obstacle', () => {
+    // Hero at (2,2) facing Leste — obstacle at (3,2)
+    expect(sensor.caminhoLivre(nivel)).toBe(false);
+  });
+
+  it('returns true when the cell ahead is empty', () => {
+    gameStateManager.moverHeroi({ direcao: 'Sul' });
+    // (2,3) is free
+    expect(sensor.caminhoLivre(nivel)).toBe(true);
+  });
+
+  it('returns false when facing the north grid boundary', () => {
+    gameStateManager.moverHeroi({ x: 0, y: 0, direcao: 'Norte' });
+    expect(sensor.caminhoLivre(nivel)).toBe(false);
+  });
+
+  it('returns false when facing the south grid boundary', () => {
+    gameStateManager.moverHeroi({ x: 0, y: 4, direcao: 'Sul' });
+    expect(sensor.caminhoLivre(nivel)).toBe(false);
+  });
+
+  it('returns false when facing the west grid boundary', () => {
+    gameStateManager.moverHeroi({ x: 0, y: 0, direcao: 'Oeste' });
+    expect(sensor.caminhoLivre(nivel)).toBe(false);
+  });
+
+  it('returns false when facing the east grid boundary', () => {
+    gameStateManager.moverHeroi({ x: 4, y: 0, direcao: 'Leste' });
+    expect(sensor.caminhoLivre(nivel)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sobreObjetivo
+// ---------------------------------------------------------------------------
+describe('SensorService.sobreObjetivo', () => {
+  it('returns false when the hero is not on the goal', () => {
+    expect(sensor.sobreObjetivo(nivel)).toBe(false);
+  });
+
+  it('returns true when the hero is on the goal', () => {
+    gameStateManager.moverHeroi({ x: 4, y: 4 });
+    expect(sensor.sobreObjetivo(nivel)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// temParede
+// ---------------------------------------------------------------------------
+describe('SensorService.temParede', () => {
+  it('returns true when an obstacle is directly ahead', () => {
+    // Hero faces east, obstacle at (3,2)
+    expect(sensor.temParede(nivel)).toBe(true);
+  });
+
+  it('returns false when the path is clear', () => {
+    gameStateManager.moverHeroi({ direcao: 'Sul' });
+    expect(sensor.temParede(nivel)).toBe(false);
+  });
+
+  it('returns true at a grid boundary', () => {
+    gameStateManager.moverHeroi({ x: 0, y: 0, direcao: 'Norte' });
+    expect(sensor.temParede(nivel)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evaluate (dispatch)
+// ---------------------------------------------------------------------------
+describe('SensorService.evaluate', () => {
+  it('delegates to caminhoLivre', () => {
+    expect(sensor.evaluate('caminhoLivre', nivel)).toBe(sensor.caminhoLivre(nivel));
+  });
+
+  it('delegates to sobreObjetivo', () => {
+    expect(sensor.evaluate('sobreObjetivo', nivel)).toBe(sensor.sobreObjetivo(nivel));
+  });
+
+  it('delegates to temParede', () => {
+    expect(sensor.evaluate('temParede', nivel)).toBe(sensor.temParede(nivel));
+  });
+
+  it('throws an Error for an unknown sensor name', () => {
+    expect(() => sensor.evaluate('voar', nivel)).toThrow(Error);
+    expect(() => sensor.evaluate('voar', nivel)).toThrow('voar');
+  });
+});


### PR DESCRIPTION
## Descrição

Este PR foi gerado automaticamente pelo **Hephaestus** para resolver a Issue #7.

**Agente executor:** Claude Code
**Workflow Run:** `4115010e-4eb7-43d0-b61a-d559b70519a8`

## Changelog

All 57 tests pass (17 existing + 18 new ConditionalCommandParser + 7 existing ExecutionQueue + 15 new SensorService).
---
## O que foi feito
### Arquivos criados
**`src/services/SensorService.js`**
Implementa `caminhoLivre()`, `sobreObjetivo()` e `temParede()` lendo o estado ao vivo do `gameStateManager`. O método `evaluate(conditionName, nivel)` faz o dispatch por nome, usado pela `ExecutionQueue` no momento do tick.
**`src/services/ConditionalCommandParser.js`**
Estende `CommandParser` via dois overrides:
- `_tokenize`: funde o token `se` com o token `(...)` seguinte, tornando `se (caminhoLivre())` → `se(caminhoLivre())` — tratado uniformemente pelo regex `SE_RE`.
- `_tryParseCustomToken`: implementa o hook adicionado ao `CommandParser` base para tratar `se(condição) { ... } [senao { ... }]`. Retorna um nó `{action:'se', condition, commands, elseCommands?}` sem avaliar a condição — isso é responsabilidade da `ExecutionQueue`.
**`src/services/SensorService.test.js`** — 15 testes cobrindo todos os sensores, bordas de grade e `evaluate`.
**`src/services/ConditionalCommandParser.test.js`** — 18 testes cobrindo `se`, `se/senao`, aninhamento com `repetir`, e erros de sintaxe.
### Arquivos modificados
**`src/services/CommandParser.js`**
- Adicionado o método `_tryParseCustomToken(_tokens, _i)` (retorna `null` por padrão) chamado em `_parseBlock` entre o tratamento do `repetir` e o matcher de comando simples. Esse hook de extensão torna a subclasse capaz de adicionar novos construtos de bloco sem copiar o loop principal.
- A mensagem de erro para `{` solitário foi generalizada para `"sem comando de bloco"` (sem quebrar testes existentes — eles cheam apenas pela presença de `"{"`).
**`src/services/ExecutionQueue.js`**
- Adicionado import de `SensorService`.
- `startTickLoop` reescrita para usar uma fila mutável (`queue`) em vez de índice fixo. `flattenActions` ainda expande `repetir` antes do início; nós `se` permanecem na fila e são avaliados no momento exato em que chegam à frente da fila (`while queue[0].action === 'se'`), garantindo que a condição reflita o estado atual do herói naquele tick. O ramo correto é expandido via `flattenActions` e inserido no início da fila (`unshift`). Nenhum tick extra é consumido na avaliação da condição.
**`src/components/CommandInput.js`**
- Import trocado de `CommandParser` para `ConditionalCommandParser`, habilitando `se`/`senao` na entrada do usuário.
- Placeholder atualizado para mostrar o padrão `se (caminhoLivre()) { ... } senao { ... }`.

---
Closes #7